### PR TITLE
Improve alt text of some images (then we got bored)

### DIFF
--- a/src/lib/Profile.svelte
+++ b/src/lib/Profile.svelte
@@ -24,6 +24,7 @@
             href="https://www.turing.ac.uk/research/research-engineering/meet-the-team"
             imgSrc={regTeam}
             title="Meet the team"
+            altText="Photograph of roughly 50 members of the Research Engineering Group on a stairwell at Away Day"
         >
             <p>
                 Learn more about our three job roles, and meet some of the
@@ -35,6 +36,7 @@
             href="https://www.turing.ac.uk/"
             imgSrc={atiSpace}
             title="The Alan Turing Institute"
+            altText="Empty office space at The Alan Turing Institute with a mural of Alan Turing in the background"
         >
             <p>
                 The Alan Turing Institute is the UK's national institute for

--- a/src/lib/grid-col/GridCol.svelte
+++ b/src/lib/grid-col/GridCol.svelte
@@ -5,11 +5,12 @@
     export let href: string;
     export let title: string;
     export let imgSrc: string;
+    export let altText: string = title;
 
     let hovered: boolean = false;
 </script>
 
-<GridImage {href} {imgSrc} alt={title} bind:hovered />
+<GridImage {href} {imgSrc} alt={altText} bind:hovered />
 <GridText {href} {title} bind:hovered>
     <slot />
 </GridText>


### PR DESCRIPTION
We found redundant alt text on the website at the RSECon 2025 accessibility seminar via the WAVE extension

https://wave.webaim.org/extension/